### PR TITLE
Add XElement.Remove() call

### DIFF
--- a/DayZLootEdit/LootType.cs
+++ b/DayZLootEdit/LootType.cs
@@ -156,6 +156,11 @@ namespace DayZLootEdit
             Nominal = (int) Math.Round(Nominal / 100.0 * percentage);
         }
 
+        public void RemoveType()
+        {
+            xtype.Remove();
+        }
+
         /*
         <type name="AKM">
             <nominal>40</nominal>

--- a/DayZLootEdit/MainWindow.xaml
+++ b/DayZLootEdit/MainWindow.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="285*"/>
             <RowDefinition Height="134*"/>
         </Grid.RowDefinitions>
-        <DataGrid x:Name="LootList" Margin="10,60,10,10" Grid.RowSpan="2" ItemsSource="{Binding LootTable.Loot}" IsEnabled="False" SelectionChanged="LootList_SelectionChanged" Grid.ColumnSpan="3">
+        <DataGrid x:Name="LootList" Margin="10,60,10,10" Grid.RowSpan="2" ItemsSource="{Binding LootTable.Loot}" IsEnabled="False" SelectionChanged="LootList_SelectionChanged" PreviewKeyDown="PreviewKeyDownHandler" Grid.ColumnSpan="3">
         </DataGrid>
         <Button x:Name="LoadBtn" Content="Load" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="40" Height="40" Click="LoadBtn_Click"/>
         <Button Content="Button" HorizontalAlignment="Left" Margin="55,10,0,0" VerticalAlignment="Top" Width="40" Height="40"/>

--- a/DayZLootEdit/MainWindow.xaml.cs
+++ b/DayZLootEdit/MainWindow.xaml.cs
@@ -108,5 +108,19 @@ namespace DayZLootEdit
         {
             LootTable.SaveFile();
         }
+
+        private void PreviewKeyDownHandler(object sender, KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.Delete:
+                case Key.Back:
+                    foreach (LootType loot in LootList.SelectedItems)
+                    {
+                        loot.RemoveType();
+                    }
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Some users are asking to be able to delete rows from the grid, so add a key press event handler that deletes the selected rows from the XML when the delete or backspace key is pressed.

Fixes #3 